### PR TITLE
Write whole user in JWT token,

### DIFF
--- a/cmd/api/server/middleware.go
+++ b/cmd/api/server/middleware.go
@@ -43,13 +43,10 @@ func (s *Server) requireLogin(next http.Handler) http.Handler {
 			return
 		}
 
-		username, err := s.Auth.DecodeToken(token)
-		if err != nil {
+		if _, err := s.Auth.DecodeToken(token); err != nil {
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return
 		}
-
-		r.Header.Add("user", username)
 
 		next.ServeHTTP(w, r)
 	})

--- a/cmd/api/server/server.go
+++ b/cmd/api/server/server.go
@@ -21,13 +21,21 @@ type UserModel interface {
 	Authenticate(email, password string) (*models.User, error)
 }
 
+// UserGameModel is the interface to interact with the Users-Games relationship provider (DB, service, etc.)
+type UserGameModel interface {
+	LinkGameToUser(userID, gameID string) error
+	GetUserGames(userID string) ([]*models.Game, error)
+}
+
 // Server is the struct that holds all the dependencies
 // needed to run the application
 type Server struct {
-	Log       *log.Logger
-	GameModel GameModel
-	UserModel UserModel
-	Auth      *auth.Authenticator
+	Log  *log.Logger
+	Auth *auth.Authenticator
+
+	GameModel
+	UserModel
+	UserGameModel
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/cmd/api/server/server_test.go
+++ b/cmd/api/server/server_test.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	authenticator = auth.NewAutheniticator("test_secret")
+	user          = &models.User{Username: "anton"}
 )
 
 func TestGetGames(t *testing.T) {
@@ -40,7 +41,7 @@ func TestGetGames(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/games", nil)
-	token, err := srv.Auth.NewTokenForUser("anton")
+	token, err := srv.Auth.NewTokenForUser(user)
 	if err != nil {
 		t.Fatalf("Got unexpected error while trying to generate token for user - %v", err)
 	}
@@ -89,7 +90,7 @@ func TestGetGamesErr(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/games", nil)
-	token, err := srv.Auth.NewTokenForUser("anton")
+	token, err := srv.Auth.NewTokenForUser(user)
 	if err != nil {
 		t.Fatalf("Got unexpected error while trying to generate token for user - %v", err)
 	}

--- a/cmd/api/server/users_handlers.go
+++ b/cmd/api/server/users_handlers.go
@@ -59,7 +59,7 @@ func (s *Server) handleUserGet() http.HandlerFunc {
 			return
 		}
 
-		username, err := s.Auth.DecodeToken(token)
+		user, err := s.Auth.DecodeToken(token)
 		if err != nil {
 			if errors.Is(err, auth.ErrInvalidSignature) || errors.Is(err, auth.ErrTokenExpired) {
 				http.Error(w, "invalid token", http.StatusUnauthorized)
@@ -68,7 +68,7 @@ func (s *Server) handleUserGet() http.HandlerFunc {
 			http.Error(w, "error while authenticating user: "+err.Error(), http.StatusInternalServerError)
 		}
 
-		s.respond(w, r, &userResponse{Username: username}, http.StatusOK)
+		s.respond(w, r, &userResponse{Username: user.Username}, http.StatusOK)
 	}
 }
 
@@ -120,7 +120,7 @@ func (s *Server) handleUserLogin() http.HandlerFunc {
 			return
 		}
 
-		token, err := s.Auth.NewTokenForUser(usr.Username)
+		token, err := s.Auth.NewTokenForUser(usr)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -2,9 +2,12 @@ package auth
 
 import (
 	"testing"
+
+	"github.com/asankov/gira/pkg/models"
 )
 
 var (
+	expectedUser     = &models.User{Username: expectedUsername}
 	expectedUsername = "username"
 )
 
@@ -12,17 +15,18 @@ func TestToken(t *testing.T) {
 
 	a := NewAutheniticator("secret")
 
-	token, err := a.NewTokenForUser(expectedUsername)
+	token, err := a.NewTokenForUser(expectedUser)
 	if err != nil {
 		t.Fatalf("got (%v), expected nil error when creating token for user", err)
 	}
 
-	username, err := a.DecodeToken(token)
+	usr, err := a.DecodeToken(token)
 	if err != nil {
 		t.Fatalf("got (%v), expected nil error when decoding token", err)
 	}
 
-	if username != expectedUsername {
-		t.Errorf("got (%v), expected (%v) for username", username, expectedUsername)
+	got, actual := usr.Username, expectedUser.Username
+	if got != actual {
+		t.Errorf("got (%v), expected (%v) for username", got, actual)
 	}
 }


### PR DESCRIPTION
not just the username.

Because it become tacky, when you decode the token and need to do a DB
lookup to find the whole info about the user