### PR TITLE
Add `.simplecov` config file

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,7 @@
+require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+   add_filter 'internal/fixtures'
+end


### PR DESCRIPTION
to exclude folders from Coveralls report and other configurations